### PR TITLE
manual scroll restoration

### DIFF
--- a/src/theme/scripts/router.js
+++ b/src/theme/scripts/router.js
@@ -87,6 +87,9 @@ class Router {
   }
 
   async navigate(link, scrollTop = 0, pushState = true) {
+    // Manually handle the scroll restoration.
+    history.scrollRestoration = 'manual';
+
     if(pushState) {
       history.replaceState({scrollTop: document.scrollingElement.scrollTop}, '');
       history.pushState({scrollTop}, '', link);
@@ -98,6 +101,9 @@ class Router {
     const headerAnimation = this._animateHeader(targetIsSingle);
     const newView = this._loadFragment(link);
     const continueAnimation = (await Promise.all([viewAnimation, headerAnimation]))[1];
+    document.scrollingElement.scrollTop = scrollTop;
+    // Set to auto in case user hits page refresh.
+    history.scrollRestoration = 'auto';
     const globalSpinner = await this._globalSpinner;
     if(await Promise.race([newView.ready, timeoutPromise(500)]) === 'timeout')
       globalSpinner.ready.then(_ => {

--- a/src/theme/scripts/router.js
+++ b/src/theme/scripts/router.js
@@ -101,9 +101,6 @@ class Router {
     const headerAnimation = this._animateHeader(targetIsSingle);
     const newView = this._loadFragment(link);
     const continueAnimation = (await Promise.all([viewAnimation, headerAnimation]))[1];
-    document.scrollingElement.scrollTop = scrollTop;
-    // Set to auto in case user hits page refresh.
-    history.scrollRestoration = 'auto';
     const globalSpinner = await this._globalSpinner;
     if(await Promise.race([newView.ready, timeoutPromise(500)]) === 'timeout')
       globalSpinner.ready.then(_ => {
@@ -112,6 +109,9 @@ class Router {
     await newView.ready;
     globalSpinner.ready.then(_ => globalSpinner.hide());
     oldView.parentNode.replaceChild(newView, oldView);
+    document.scrollingElement.scrollTop = scrollTop;
+    // Set to auto in case user hits page refresh.
+    history.scrollRestoration = 'auto';
     await Promise.all([this._animateIn(newView), continueAnimation()]);
     _pubsubhub.dispatch('navigation', {address: link});
   }


### PR DESCRIPTION
Fixes #9  by manually handling scroll restoration. 
We wait for the view animate out to be done, then we scroll to the right spot 👌
We set `history.scrollRestoration = "auto"` so that if the user hits the page refresh, he'll be scrolled to the right spot again