### PR TITLE
Add custom elements on content output

### DIFF
--- a/src/pwp-lazy-image-plugin/pwp-lazy-image-plugin.php
+++ b/src/pwp-lazy-image-plugin/pwp-lazy-image-plugin.php
@@ -74,5 +74,5 @@
       return '<pwp-lazy-image src="' . $img_path . '" width="'. $thumb['width'] . '" height="' . $thumb['height'] .'" style="padding-top: '.$thumb['ratio'].'%; background-image: url(data:image/png;base64,' . $thumb['base64'] . ');"></pwp-lazy-image>';
     }, $content);
   }
-  add_filter('content_save_pre' , 'lazify_images', 0, 1);
+  add_filter('the_content' , 'lazify_images', 0, 1);
 ?>


### PR DESCRIPTION
By using `the_content` filter instead of `content_save_pre`, the custom element `<pwp-lazy-image>` is added on the fly before the content output. This approach avoid to get stuck to PWP Lazy Image plugin in the future: you will be able to switch between themes, lazy load plugins, or even between publishing platforms without the need to rewrite every post.